### PR TITLE
allow nullable response parameters

### DIFF
--- a/src/OpenApi/OpenApiSchemaParser.php
+++ b/src/OpenApi/OpenApiSchemaParser.php
@@ -44,6 +44,11 @@ final class OpenApiSchemaParser
     private function extractData(array $data): array
     {
         $aux = [];
+
+        if (\array_key_exists('nullable', $data)) {
+            $data = $this->convertNullableTypeToJsonSchema($data);
+        }
+
         foreach ($data as $key => $elem) {
             if ('$ref' === $key) {
                 $aux = $this->findDefinition($elem);
@@ -115,5 +120,21 @@ final class OpenApiSchemaParser
                 )
             );
         }
+    }
+
+    private function convertNullableTypeToJsonSchema(array $data): array
+    {
+        $data['oneOf'] = [
+            ['type' => null],
+        ];
+
+        if (\array_key_exists('type', $data)) {
+            $data['oneOf'][] = ['type' => $data['type']];
+            unset($data['type']);
+        }
+
+        unset($data['nullable']);
+
+        return $data;
     }
 }


### PR DESCRIPTION
When I have the following set on Open Api:
```
"contact_email": {
      "type":"string",
      "nullable":true,
      "format": ""
}
```

This pleases the API docs, but rightfully breaks the JSON Schema validation when some of my responses go through, as the null value isn't adhered too, which is correct as per the JSON schema.

Json schema should be:
```
"contact_email": {
      "oneOf": {
            {"type":"string"},
            {"type": null},
      },
      "format": ""
}
```