### PR TITLE
Feature/support for multiple same messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ composer.phar
 ###< IDEA ###
 ###> phpunit ###
 .phpunit
+.phpunit.result.cache
 /phpunit.xml
 ###< phpunit ###
 

--- a/src/OpenApi/JsonValidation.php
+++ b/src/OpenApi/JsonValidation.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\OpenApi;
+
+final class JsonValidation
+{
+    private string $json;
+    private ?string $errorMessage;
+
+    public function __construct(string $json, ?string $errorMessage)
+    {
+        $this->json = $json;
+        $this->errorMessage = $errorMessage;
+    }
+
+    public function hasError(): bool
+    {
+        return null !== $this->errorMessage;
+    }
+
+    public function json(): string
+    {
+        return $this->json;
+    }
+
+    public function errorMessage(): ?string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/src/OpenApi/JsonValidationCollection.php
+++ b/src/OpenApi/JsonValidationCollection.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\OpenApi;
+
+final class JsonValidationCollection
+{
+    private array $jsonValidations;
+
+    public function __construct(JsonValidation ...$jsonValidations)
+    {
+        $this->jsonValidations = $jsonValidations;
+    }
+
+    public function hasAnyError()
+    {
+        foreach ($this->jsonValidations as $theJsonValidation) {
+            if (true === $theJsonValidation->hasError()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function buildErrorMessage(): string
+    {
+        if (false === $this->hasAnyError()) {
+            return '';
+        }
+
+        $validationsWithErrors = \array_filter(
+            $this->jsonValidations,
+            static fn(JsonValidation $elem) => $elem->hasError()
+        );
+
+        $msg = PHP_EOL;
+        foreach ($validationsWithErrors as $index => $validation) {
+            $msg .= sprintf('JSON message %d does not validate. ' . PHP_EOL, $index);
+            $msg .= $validation->errorMessage();
+        }
+
+        return $msg;
+    }
+}

--- a/src/OpenApi/JsonValidationException.php
+++ b/src/OpenApi/JsonValidationException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\OpenApi;
+
+final class JsonValidationException extends \Exception
+{
+
+}

--- a/src/OpenApi/JsonValidator.php
+++ b/src/OpenApi/JsonValidator.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\OpenApi;
+
+use JsonSchema\Validator;
+
+final class JsonValidator
+{
+    private string $jsonToValidate;
+    private JsonSchema $jsonSchema;
+
+    public function __construct(string $jsonToValidate, JsonSchema $jsonSchema)
+    {
+        $this->jsonToValidate = $jsonToValidate;
+        $this->jsonSchema = $jsonSchema;
+    }
+
+    public function validate(): JsonValidation
+    {
+        return $this->jsonSchema->validate($this->jsonToValidate, new Validator());
+    }
+}

--- a/tests/AsyncApi/AsyncApiParserTest.php
+++ b/tests/AsyncApi/AsyncApiParserTest.php
@@ -3,6 +3,7 @@
 namespace PcComponentes\OpenApiMessagingContext\Tests\AsyncApi;
 
 use PcComponentes\OpenApiMessagingContext\AsyncApi\AsyncApiParser;
+use PcComponentes\OpenApiMessagingContext\Tests\Messaging\DomainEventFake;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 
@@ -12,7 +13,7 @@ final class AsyncApiParserTest extends TestCase
     public function given_valid_schema_when_parse_v12_then_get_parsed_schema(): void
     {
         $allSpec = Yaml::parse(file_get_contents(__DIR__ . '/valid-asyncapi-v12-spec.yaml'));
-        $schema = (new AsyncApiParser($allSpec))->parse('pccomponentes.test.testtopic');
+        $schema = (new AsyncApiParser($allSpec))->parse(DomainEventFake::messageName());
         $jsonCompleted = '{"type":"object","required":["message_id","type"],"properties":{"message_id":{"type":"string"},"type":{"type":"string"},"attributes":{"type":"object","required":["some_attribute"],"properties":{"some_attribute":{"type":"string"}}}}}';
         $this->assertJsonStringEqualsJsonString(\json_encode($schema), $jsonCompleted);
     }
@@ -30,7 +31,7 @@ final class AsyncApiParserTest extends TestCase
     public function given_valid_schema_when_parse_v20_then_get_parsed_schema(): void
     {
         $allSpec = Yaml::parse(file_get_contents(__DIR__ . '/valid-asyncapi-v20-spec.yaml'));
-        $schema = (new AsyncApiParser($allSpec))->parse('pccomponentes.test.testtopic');
+        $schema = (new AsyncApiParser($allSpec))->parse(DomainEventFake::messageName());
         $jsonCompleted = '{"type":"object","required":["message_id","type"],"properties":{"message_id":{"type":"string"},"type":{"type":"string"},"attributes":{"type":"object","required":["some_attribute"],"properties":{"some_attribute":{"type":"string"}}}}}';
         $this->assertJsonStringEqualsJsonString(\json_encode($schema), $jsonCompleted);
     }

--- a/tests/AsyncApi/valid-asyncapi-v12-spec.yaml
+++ b/tests/AsyncApi/valid-asyncapi-v12-spec.yaml
@@ -7,7 +7,7 @@ info:
 baseTopic: 'pccomponentes.test'
 
 topics:
-  testtopic:
+  1.domain_event.test_context.test_name:
     publish:
       $ref: "#/components/messages/TestTopicRef"
 

--- a/tests/AsyncApi/valid-asyncapi-v20-spec.yaml
+++ b/tests/AsyncApi/valid-asyncapi-v20-spec.yaml
@@ -6,7 +6,7 @@ info:
     Spec for testing purpose
 
 channels:
-  pccomponentes.test.testtopic:
+  pccomponentes.test.1.domain_event.test_context.test_name:
     publish:
       message:
         $ref: "#/components/messages/TestTopicRef"

--- a/tests/Behat/MessageValidatorOpenApiContextTest.php
+++ b/tests/Behat/MessageValidatorOpenApiContextTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Tests\Behat;
+
+use PcComponentes\Ddd\Domain\Model\ValueObject\DateTimeValueObject;
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+use PcComponentes\Ddd\Util\Message\AggregateMessage;
+use PcComponentes\Ddd\Util\Message\Message;
+use PcComponentes\OpenApiMessagingContext\Behat\MessageValidatorOpenApiContext;
+use PcComponentes\OpenApiMessagingContext\Messaging\SpyMiddleware;
+use PcComponentes\OpenApiMessagingContext\OpenApi\JsonValidationException;
+use PcComponentes\OpenApiMessagingContext\Tests\Messaging\DomainEventFake;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+
+class MessageValidatorOpenApiContextTest extends TestCase
+{
+    private MessageValidatorOpenApiContext $messageValidatorOpenApiContext;
+    private SpyMiddleware $spyMiddleware;
+
+    protected function setUp(): void
+    {
+        $this->spyMiddleware = new SpyMiddleware();
+        $this->messageValidatorOpenApiContext = new MessageValidatorOpenApiContext(
+            __DIR__,
+            $this->spyMiddleware,
+        );
+        $this->spyMiddleware->reset();
+    }
+
+    /** @test */
+    public function given_correct_json_and_openapi_when_validate_then_ok(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->prepareMessage(
+            $this->fakeDomainEvent(
+                [
+                    'some_attribute' => 'some_string',
+                ],
+            ),
+        );
+
+        $this->messageValidatorOpenApiContext->theMessageShouldBeValidAccordingToTheSwagger(
+            DomainEventFake::messageName(),
+            '../AsyncApi/valid-asyncapi-v20-spec.yaml',
+        );
+    }
+
+    /** @test */
+    public function given_incorrect_json_and_openapi_when_validate_then_validation_exception(): void
+    {
+        $this->expectException(JsonValidationException::class);
+        $this->prepareMessage(
+            $this->fakeDomainEvent(
+                [
+                    'foo_attribute' => 'bar',
+                ],
+            ),
+        );
+
+        $this->messageValidatorOpenApiContext->theMessageShouldBeValidAccordingToTheSwagger(
+            DomainEventFake::messageName(),
+            '../AsyncApi/valid-asyncapi-v20-spec.yaml',
+        );
+    }
+
+    /** @test */
+    public function given_one_message_when_count_messages_then_ok(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->prepareMessage($this->fakeDomainEvent([]));
+
+        $this->messageValidatorOpenApiContext->theMessageShouldBeDispatchedManyTimes(DomainEventFake::messageName(), 1);
+    }
+
+    /** @test */
+    public function given_multiple_message_when_count_messages_then_ok(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->prepareMessage($this->fakeDomainEvent([]));
+        $this->prepareMessage($this->fakeDomainEvent([]));
+        $this->prepareMessage($this->fakeDomainEvent([]));
+
+        $this->messageValidatorOpenApiContext->theMessageShouldBeDispatchedManyTimes(DomainEventFake::messageName(), 3);
+    }
+
+    /** @test */
+    public function given_multiple_message_when_count_wrong_messages_then_exception(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->prepareMessage($this->fakeDomainEvent([]));
+
+        $this->messageValidatorOpenApiContext->theMessageShouldBeDispatchedManyTimes(DomainEventFake::messageName(), 3);
+    }
+
+    public function prepareMessage(Message $message): void
+    {
+        $this->spyMiddleware->handle(
+            new Envelope($message),
+            new StackMiddleware(),
+        );
+    }
+
+    private function fakeDomainEvent(array $attributes): AggregateMessage
+    {
+        return DomainEventFake::fromPayload(
+            Uuid::from('efcf7fc2-2d6b-4a52-9763-4472a37b3c24'),
+            Uuid::from('efcf7fc2-2d6b-4a52-9763-4472a37b3c25'),
+            new DateTimeValueObject(),
+            $attributes,
+        );
+    }
+}

--- a/tests/Messaging/CommandFake.php
+++ b/tests/Messaging/CommandFake.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Tests\Messaging;
+
+use PcComponentes\Ddd\Application\Command;
+
+final class CommandFake extends Command
+{
+    protected function assertPayload(): void
+    {
+        //nothing
+    }
+
+    public static function messageName(): string
+    {
+        return 'pccomponentes.'
+            . 'test.'
+            . self::messageVersion() . '.'
+            . self::messageType() . '.'
+            . 'test_context' . '.'
+            . 'test_name';
+    }
+
+    public static function messageVersion(): string
+    {
+        return '1';
+    }
+}

--- a/tests/Messaging/DomainEventFake.php
+++ b/tests/Messaging/DomainEventFake.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Tests\Messaging;
+
+use PcComponentes\Ddd\Domain\Model\DomainEvent;
+
+final class DomainEventFake extends DomainEvent
+{
+    protected function assertPayload(): void
+    {
+        //nothing
+    }
+
+    public static function messageName(): string
+    {
+        return 'pccomponentes.'
+            . 'test.'
+            . self::messageVersion() . '.'
+            . self::messageType() . '.'
+            . 'test_context' . '.'
+            . 'test_name';
+    }
+
+    public static function messageVersion(): string
+    {
+        return '1';
+    }
+}

--- a/tests/Messaging/SpyMiddlewareTest.php
+++ b/tests/Messaging/SpyMiddlewareTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PcComponentes\OpenApiMessagingContext\Tests\Messaging;
 
+use PcComponentes\Ddd\Domain\Model\ValueObject\DateTimeValueObject;
 use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+use PcComponentes\Ddd\Util\Message\AggregateMessage;
+use PcComponentes\Ddd\Util\Message\Message;
 use PcComponentes\Ddd\Util\Message\SimpleMessage;
 use PcComponentes\OpenApiMessagingContext\Messaging\SpyMiddleware;
 use PcComponentes\OpenApiMessagingContext\Serialization\SchemaValidatorSimpleMessageSerializable;
@@ -57,7 +60,7 @@ class SpyMiddlewareTest extends TestCase
     public function given_handled_message_when_get_message_then_return_message(): void
     {
         $command = $this->fakeCommand();
-        $this->prepareCustomCommand($command);
+        $this->prepareCustomMessage($command);
 
         $message = $this->spyMiddleware->getMessage($command::messageName());
 
@@ -71,7 +74,56 @@ class SpyMiddlewareTest extends TestCase
         $this->spyMiddleware->getMessage(CommandFake::messageName());
     }
 
-    private function prepareCustomCommand(SimpleMessage $message): void
+    /** @test */
+    public function given_multiple_same_handled_message_when_get_all_messages_then_return_all(): void
+    {
+        $command = $this->fakeCommand();
+        $this->prepareCustomMessage($command);
+        $this->prepareCustomMessage($command);
+
+        $result = $this->spyMiddleware->getMessagesFromName($command::messageName());
+
+        self::assertCount(2, $result);
+        self::assertEquals($this->serializer->serialize($command), $result[0]);
+        self::assertEquals($this->serializer->serialize($command), $result[1]);
+    }
+
+    /** @test */
+    public function given_multiple_same_handled_message_when_count_messages_then_assert_counts(): void
+    {
+        $command = $this->fakeCommand();
+        $this->prepareCustomMessage($command);
+        $this->prepareCustomMessage($command);
+
+        $result = $this->spyMiddleware->countMessagesFromName($command::messageName());
+
+        self::assertEquals(2, $result);
+    }
+
+    /** @test */
+    public function given_non_handled_message_when_count_messages_then_return_zero(): void
+    {
+        $result = $this->spyMiddleware->countMessagesFromName(CommandFake::messageName());
+
+        self::assertEquals(0, $result);
+    }
+
+    /** @test */
+    public function given_multiple_distinct_handled_message_when_count_messages_then_assert_counts(): void
+    {
+        $command = $this->fakeCommand();
+        $event = $this->fakeDomainEvent();
+        $this->prepareCustomMessage($command);
+        $this->prepareCustomMessage($event);
+
+        $resultCommand = $this->spyMiddleware->countMessagesFromName(CommandFake::messageName());
+        $resultEvent = $this->spyMiddleware->countMessagesFromName(DomainEventFake::messageName());
+
+        self::assertEquals(1, $resultCommand);
+        self::assertEquals(1, $resultEvent);
+    }
+
+    private function prepareCustomMessage(Message $message): void
     {
         $this->spyMiddleware->handle(new Envelope($message), new StackMiddleware());
     }
@@ -88,6 +140,16 @@ class SpyMiddlewareTest extends TestCase
     {
         return CommandFake::fromPayload(
             Uuid::from('efcf7fc2-2d6b-4a52-9763-4472a37b3c23'),
+            [],
+        );
+    }
+
+    private function fakeDomainEvent(): AggregateMessage
+    {
+        return DomainEventFake::fromPayload(
+            Uuid::from('efcf7fc2-2d6b-4a52-9763-4472a37b3c24'),
+            Uuid::from('efcf7fc2-2d6b-4a52-9763-4472a37b3c25'),
+            new DateTimeValueObject(),
             [],
         );
     }

--- a/tests/Messaging/SpyMiddlewareTest.php
+++ b/tests/Messaging/SpyMiddlewareTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Tests\Messaging;
+
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+use PcComponentes\Ddd\Util\Message\SimpleMessage;
+use PcComponentes\OpenApiMessagingContext\Messaging\SpyMiddleware;
+use PcComponentes\OpenApiMessagingContext\Serialization\SchemaValidatorSimpleMessageSerializable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+
+class SpyMiddlewareTest extends TestCase
+{
+    private SpyMiddleware $spyMiddleware;
+    private SchemaValidatorSimpleMessageSerializable $serializer;
+
+    public function setUp(): void
+    {
+        $this->serializer = new SchemaValidatorSimpleMessageSerializable();
+        $this->spyMiddleware = new SpyMiddleware();
+        $this->spyMiddleware->reset();
+    }
+
+    /** @test */
+    public function given_handled_message_when_has_message_then_return_true(): void
+    {
+        $this->prepareCommandMessage();
+
+        $result = $this->spyMiddleware->hasMessage(CommandFake::messageName());
+
+        self::assertTrue($result);
+    }
+
+    /** @test */
+    public function given_non_handled_message_when_has_message_then_return_false(): void
+    {
+        $result = $this->spyMiddleware->hasMessage(CommandFake::messageName());
+
+        self::assertFalse($result);
+    }
+
+    /** @test */
+    public function given_handled_message_when_reset_then_has_message_false(): void
+    {
+        $this->prepareCommandMessage();
+        $this->spyMiddleware->reset();
+
+        $result = $this->spyMiddleware->hasMessage(CommandFake::messageName());
+
+        self::assertFalse($result);
+    }
+
+    /** @test */
+    public function given_handled_message_when_get_message_then_return_message(): void
+    {
+        $command = $this->fakeCommand();
+        $this->prepareCustomCommand($command);
+
+        $message = $this->spyMiddleware->getMessage($command::messageName());
+
+        self::assertEquals($this->serializer->serialize($command), $message);
+    }
+
+    /** @test */
+    public function given_non_handled_message_when_get_message_then_expect_exception(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->spyMiddleware->getMessage(CommandFake::messageName());
+    }
+
+    private function prepareCustomCommand(SimpleMessage $message): void
+    {
+        $this->spyMiddleware->handle(new Envelope($message), new StackMiddleware());
+    }
+
+    public function prepareCommandMessage(): void
+    {
+        $this->spyMiddleware->handle(
+            new Envelope($this->fakeCommand()),
+            new StackMiddleware(),
+        );
+    }
+
+    private function fakeCommand(): SimpleMessage
+    {
+        return CommandFake::fromPayload(
+            Uuid::from('efcf7fc2-2d6b-4a52-9763-4472a37b3c23'),
+            [],
+        );
+    }
+}


### PR DESCRIPTION
Add support for multiple same messages dispatched in same use case. 

New _Then_ step added for `MessageValidatorOpenApiContext`:
* Then the message :name should be dispatched :times times

Example:
```gherking
Then the message "pccomponentes.test.1.domain_event.test.test" should be dispatched 3 times
```

Added some test for `SpyMiddleware` and `MessageValidatorOpenApiContext` and refactor JSON validation process.