### PR TITLE
Add new features to test failing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When I receive a simple message with payload:
 """
 Then the message "pccomponentes.example.1.domain_event.resource.resource_created" should be dispatched
 ```
-This is useful to combine it with `Then` step in `MessageValidatorOpenApiContext`
+This is useful to combine it with `Then` step in `MessageValidatorOpenApiContext`, also you can combine them with expected message exceptions.
 
 Configuration:
 ```yaml

--- a/src/Behat/SimpleMessageContext.php
+++ b/src/Behat/SimpleMessageContext.php
@@ -38,7 +38,7 @@ final class SimpleMessageContext implements Context
     /**
      * @When I receive a simple failing message with payload:
      */
-    public function dispatchMessage(PyStringNode $payload): void
+    public function dispatchFailingMessage(PyStringNode $payload): void
     {
         try {
             $this->dispatchMessage($payload);

--- a/src/Behat/SimpleMessageContext.php
+++ b/src/Behat/SimpleMessageContext.php
@@ -14,6 +14,7 @@ final class SimpleMessageContext implements Context
 {
     private MessageBusInterface $bus;
     private SimpleMessageUnserializable $simpleMessageUnserializable;
+    private \Throwable $lastException;
 
     public function __construct(
         MessageBusInterface $bus,
@@ -34,6 +35,42 @@ final class SimpleMessageContext implements Context
         $this->bus->dispatch($message);
     }
 
+    /**
+     * @When I receive a simple failing message with payload:
+     */
+    public function dispatchMessage(PyStringNode $payload): void
+    {
+        try {
+            $this->dispatchMessage($payload);
+        } catch (\Throwable $exception) {
+            $this->lastException = $exception;
+
+            return;
+        }
+
+        $message = 'Expecting a failed message';
+
+        throw new \Exception($message);
+    }
+
+    /**
+     * @Then exception class for the last message should be :exceptionType
+     */
+    public function checkExceptionClass($exceptionType): void
+    {
+        if (get_class($this->lastException) === $exceptionType) {
+            return;
+        }
+
+        $message = \sprintf(
+            'Expecting a failed message with exception \'%s\' but got \'%s\'',
+            $exceptionType,
+            get_class($this->lastException),
+        );
+
+        throw new \Exception($message);
+    }
+    
     private function payloadToStream(string $rawPayload): SimpleMessageStream
     {
         $payload = \json_decode($rawPayload, true, 512, \JSON_THROW_ON_ERROR);


### PR DESCRIPTION
This PR add new validations for the `SimpleMessageContext` context:

### `@When I receive a simple failing message with payload:`
The same as the standard one, but this expects a failing message (an exception should be thrown)

### `@Then exception class for the last message should be :exceptionType`
This validation checks that the expected exception for the last message should match the provided one.