### PR TITLE
feat: New implementation of ResponseValidatorOpenApiContext

### DIFF
--- a/src/Behat/ResponseValidatorOpenApiContext.php
+++ b/src/Behat/ResponseValidatorOpenApiContext.php
@@ -4,20 +4,16 @@ declare(strict_types=1);
 namespace PcComponentes\OpenApiMessagingContext\Behat;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\MinkExtension\Context\MinkContext;
 use PcComponentes\OpenApiMessagingContext\OpenApi\JsonSchema;
 use PcComponentes\OpenApiMessagingContext\OpenApi\JsonValidationException;
 use PcComponentes\OpenApiMessagingContext\OpenApi\JsonValidator;
 use PcComponentes\OpenApiMessagingContext\OpenApi\OpenApiSchemaParser;
 use Symfony\Component\Yaml\Yaml;
 
-final class ResponseValidatorOpenApiContext implements Context
+abstract class ResponseValidatorOpenApiContext implements Context
 {
-    private const CONTENT_TYPE_RESPONSE_HEADER_KEY = 'content-type';
     private const HTTP_NO_CONTENT_CODE = 204;
 
-    private MinkContext $minkContext;
     private string $rootPath;
 
     public function __construct(string $rootPath)
@@ -26,27 +22,22 @@ final class ResponseValidatorOpenApiContext implements Context
     }
 
     /**
-     * @BeforeScenario
-     */
-    public function bootstrapEnvironment(BeforeScenarioScope $scope): void
-    {
-        $this->minkContext = $scope->getEnvironment()->getContext(MinkContext::class);
-    }
-
-    /**
      * @Then the JSON response should be valid according to OpenApi :dumpPath schema :schema
      */
     public function theJsonResponseShouldBeValidAccordingToOpenApiSchema($dumpPath, $schema): void
     {
-        $path = realpath($this->rootPath . '/' . $dumpPath);
+        $path = \realpath($this->rootPath . '/' . $dumpPath);
         $this->checkSchemaFile($path);
 
-        $responseJson = $this->minkContext->getSession()->getPage()->getContent();
+        $responseJson = $this->extractContent();
 
         $allSpec = Yaml::parse(file_get_contents($path));
         $schemaSpec = (new OpenApiSchemaParser($allSpec))->parse($schema);
 
-        $validator = new JsonValidator($responseJson, new JsonSchema(\json_decode(\json_encode($schemaSpec), false)));
+        $validator = new JsonValidator(
+            $responseJson,
+            new JsonSchema(\json_decode(\json_encode($schemaSpec), false)),
+        );
         $validation = $validator->validate();
 
         if ($validation->hasError()) {
@@ -63,15 +54,23 @@ final class ResponseValidatorOpenApiContext implements Context
         $this->checkSchemaFile($path);
 
         $statusCode = $this->extractStatusCode();
-        $method = $this->extractMethod();
-        $contentType = $this->extractContentType();
+        $method = \strtolower($this->extractMethod());
+        $contentType = $this->contentType();
 
-        $responseJson = $this->minkContext->getSession()->getPage()->getContent();
+        $responseJson = $this->extractContent();
 
         $allSpec = Yaml::parse(\file_get_contents($path));
-        $schemaSpec = (new OpenApiSchemaParser($allSpec))->fromResponse($openApiPath, $method, $statusCode, $contentType);
+        $schemaSpec = (new OpenApiSchemaParser($allSpec))->fromResponse(
+            $openApiPath,
+            $method,
+            $statusCode,
+            $contentType,
+        );
 
-        $validator = new JsonValidator($responseJson, new JsonSchema(\json_decode(\json_encode($schemaSpec), false)));
+        $validator = new JsonValidator(
+            $responseJson,
+            new JsonSchema(\json_decode(\json_encode($schemaSpec), false)),
+        );
         $validation = $validator->validate();
 
         if ($validation->hasError()) {
@@ -79,40 +78,34 @@ final class ResponseValidatorOpenApiContext implements Context
         }
     }
 
+    abstract protected function extractMethod(): string;
+
+    abstract protected function extractContentType(): ?string;
+
+    abstract protected function extractStatusCode(): int;
+
+    abstract protected function extractContent(): string;
+
     private function checkSchemaFile($filename): void
     {
         if (false === \is_file($filename)) {
             throw new \RuntimeException(
-                'The JSON schema doesn\'t exist'
+                "The JSON schema doesn't exist",
             );
         }
     }
 
-    private function extractMethod(): string
-    {
-        /** @var Client $requestClient */
-        $requestClient = $this->minkContext->getSession()->getDriver()->getClient();
-        $method = $requestClient->getHistory()->current()->getMethod();
-
-        return \strtolower($method);
-    }
-
-    private function extractStatusCode(): int
-    {
-        return $this->minkContext->getSession()->getStatusCode();
-    }
-
-    private function extractContentType(): string
+    private function contentType(): string
     {
         if (self::HTTP_NO_CONTENT_CODE === $this->extractStatusCode()) {
             return '';
         }
 
-        $contentType = $this->minkContext->getSession()->getResponseHeader(self::CONTENT_TYPE_RESPONSE_HEADER_KEY);
+        $contentType = $this->extractContentType();
 
         if (null === $contentType) {
             throw new \RuntimeException(
-                'HTTP content-type response header key not defined'
+                'HTTP content-type response header key not defined',
             );
         }
 

--- a/src/Behat/ResponseValidatorOpenApiContext/MinkResponseValidatorOpenApiContext.php
+++ b/src/Behat/ResponseValidatorOpenApiContext/MinkResponseValidatorOpenApiContext.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Behat\ResponseValidatorOpenApiContext;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\MinkContext;
+use PcComponentes\OpenApiMessagingContext\Behat\ResponseValidatorOpenApiContext;
+
+final class MinkResponseValidatorOpenApiContext extends ResponseValidatorOpenApiContext
+{
+    private const CONTENT_TYPE_RESPONSE_HEADER_KEY = 'content-type';
+
+    private MinkContext $minkContext;
+
+    /**
+     * @BeforeScenario
+     */
+    public function bootstrapEnvironment(BeforeScenarioScope $scope): void
+    {
+        $this->minkContext = $scope->getEnvironment()->getContext(MinkContext::class);
+    }
+
+    protected function extractMethod(): string
+    {
+        $requestClient = $this->minkContext->getSession()->getDriver()->getClient();
+
+        return $requestClient->getHistory()->current()->getMethod();
+    }
+
+    protected function extractContentType(): ?string
+    {
+        return $this->minkContext->getSession()->getResponseHeader(self::CONTENT_TYPE_RESPONSE_HEADER_KEY);
+    }
+
+    protected function extractStatusCode(): int
+    {
+        return $this->minkContext->getSession()->getStatusCode();
+    }
+
+    protected function extractContent(): string
+    {
+        return $this->minkContext->getSession()->getPage()->getContent();
+    }
+}

--- a/src/Behat/ResponseValidatorOpenApiContext/RequestHistoryResponseValidatorOpenApiContext.php
+++ b/src/Behat/ResponseValidatorOpenApiContext/RequestHistoryResponseValidatorOpenApiContext.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Behat\ResponseValidatorOpenApiContext;
+
+use PcComponentes\OpenApiMessagingContext\Behat\ResponseValidatorOpenApiContext;
+use PcComponentes\OpenApiMessagingContext\Utils\RequestHistory;
+
+final class RequestHistoryResponseValidatorOpenApiContext extends ResponseValidatorOpenApiContext
+{
+    private const CONTENT_TYPE_RESPONSE_HEADER_KEY = 'content-type';
+
+    private RequestHistory $requestHistory;
+
+    public function __construct(string $rootPath, RequestHistory $requestHistory)
+    {
+        parent::__construct($rootPath);
+
+        $this->requestHistory = $requestHistory;
+    }
+
+    protected function extractMethod(): string
+    {
+        return $this->requestHistory->getLastRequest()->getMethod();
+    }
+
+    protected function extractContentType(): ?string
+    {
+        return $this->requestHistory->getLastResponse()->headers->get(self::CONTENT_TYPE_RESPONSE_HEADER_KEY);
+    }
+
+    protected function extractStatusCode(): int
+    {
+        return $this->requestHistory->getLastResponse()->getStatusCode();
+    }
+
+    protected function extractContent(): string
+    {
+        return $this->requestHistory->getLastResponse()->getContent();
+    }
+}

--- a/src/Utils/RequestHistory.php
+++ b/src/Utils/RequestHistory.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\OpenApiMessagingContext\Utils;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class RequestHistory
+{
+    private array $requests;
+    private array $responses;
+
+    public function __construct()
+    {
+        $this->requests = [];
+        $this->responses = [];
+    }
+
+    public function add(Request $request, Response $response): void
+    {
+        $this->requests[] = $request;
+        $this->responses[] = $response;
+    }
+
+    public function getLastRequest(): Request
+    {
+        return \end($this->requests);
+    }
+
+    public function getLastResponse(): Response
+    {
+        return \end($this->responses);
+    }
+
+    public function reset(): void
+    {
+        $this->requests = [];
+        $this->responses = [];
+    }
+}


### PR DESCRIPTION
The **MessageValidatorOpenApiContext** class has been transformed to abstract to obtain 2 implementations:
- Mink (Current)
- **RequestHistory (New)**: an in-memory collection of requests and responses. This implementation is intended to use internal symfony kernel calls in another context and save resources by not having to instantiate symfony objects again on each request.