### PR TITLE
Feature/Add request validation using openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,17 @@ Configuration:
 ```
 
 ## ResponseValidatorOpenApiContext
+Check if http requests are documented in your openapi file:
+```gherkin
+Then the request should be valid according to OpenApi "docs/openapi.yml" with path "/your/openapi/path/"
+```
 Check if http responses are documented in your openapi file:
 ```gherkin
 Then the response should be valid according to OpenApi "docs/openapi.yml" with path "/your/openapi/path/"
+```
+Additionally, you can check both the request and response with:
+```gherkin
+Then the request and response should be valid according to OpenApi "docs/openapi.yml" with path "/your/openapi/path/"
 ```
 Configuration:
 ```yaml

--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,5 @@
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
     "sort-packages": true
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-feature/add-request-validation-using-openapi": "4.0-dev"
-    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
     "sort-packages": true
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "4.0-dev"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "4.0-dev"
+      "dev-feature/add-request-validation-using-openapi": "4.0-dev"
     }
   }
 }

--- a/src/Behat/ResponseValidatorOpenApiContext/MinkResponseValidatorOpenApiContext.php
+++ b/src/Behat/ResponseValidatorOpenApiContext/MinkResponseValidatorOpenApiContext.php
@@ -7,6 +7,9 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\MinkContext;
 use PcComponentes\OpenApiMessagingContext\Behat\ResponseValidatorOpenApiContext;
 
+/**
+ * @deprecated No longer used. Open an issue to let us know if you do, and kindly implement extractRequestContentType() and extractRequestContent()
+ */
 final class MinkResponseValidatorOpenApiContext extends ResponseValidatorOpenApiContext
 {
     private const CONTENT_TYPE_RESPONSE_HEADER_KEY = 'content-type';
@@ -26,7 +29,12 @@ final class MinkResponseValidatorOpenApiContext extends ResponseValidatorOpenApi
         return $requestClient->getHistory()->current()->getMethod();
     }
 
-    protected function extractContentType(): ?string
+    protected function extractRequestContentType(): ?string
+    {
+        throw new \LogicException('Not implemented');
+    }
+
+    protected function extractResponseContentType(): ?string
     {
         return $this->minkContext->getSession()->getResponseHeader(self::CONTENT_TYPE_RESPONSE_HEADER_KEY);
     }
@@ -36,7 +44,12 @@ final class MinkResponseValidatorOpenApiContext extends ResponseValidatorOpenApi
         return $this->minkContext->getSession()->getStatusCode();
     }
 
-    protected function extractContent(): string
+    protected function extractRequestContent(): string
+    {
+        throw new \LogicException('Not implemented');
+    }
+
+    protected function extractResponseContent(): string
     {
         return $this->minkContext->getSession()->getPage()->getContent();
     }

--- a/src/Behat/ResponseValidatorOpenApiContext/RequestHistoryResponseValidatorOpenApiContext.php
+++ b/src/Behat/ResponseValidatorOpenApiContext/RequestHistoryResponseValidatorOpenApiContext.php
@@ -21,7 +21,14 @@ final class RequestHistoryResponseValidatorOpenApiContext extends ResponseValida
         return $this->requestHistory->getLastRequest()->getMethod();
     }
 
-    protected function extractContentType(): ?string
+    protected function extractRequestContentType(): ?string
+    {
+        $request = $this->requestHistory->getLastRequest();
+
+        return $request->getMimeType($request->getContentType());
+    }
+
+    protected function extractResponseContentType(): ?string
     {
         return $this->requestHistory->getLastResponse()->headers->get(self::CONTENT_TYPE_RESPONSE_HEADER_KEY);
     }
@@ -31,7 +38,12 @@ final class RequestHistoryResponseValidatorOpenApiContext extends ResponseValida
         return $this->requestHistory->getLastResponse()->getStatusCode();
     }
 
-    protected function extractContent(): string
+    protected function extractRequestContent(): string
+    {
+        return $this->requestHistory->getLastRequest()->getContent();
+    }
+
+    protected function extractResponseContent(): string
     {
         return $this->requestHistory->getLastResponse()->getContent();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes -->
## Related Issue
This adds the ability to validate API request body against OpenAPI schema:

```gherkin
Then the request should be valid according to OpenApi "docs/openapi.yml" with path "/your/openapi/path/"
```

```gherkin
Then the request and response should be valid according to OpenApi "docs/openapi.yml" with path "/your/openapi/path/"
```

## Main changes

<!--- What types of changes does your code introduce? Add a short description: -->

- :new: &nbsp; **(feat):** Added request body validation against OpenAPI